### PR TITLE
Add Japanese README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,40 @@
+# InMirror 日本語版
+
+English version is available in [README.md](README.md).
+
+このリポジトリは Unity で作成されたシンプルな AR/VR ポータルデモを含んでいます。ポータル効果を通じて拡張現実と仮想現実の世界を切り替える方法を示します。
+
+## プロジェクトを開く手順
+1. **Unity 6000.0.36f1** 以降をインストールします。
+2. このリポジトリをクローンし、Unity Hub を起動します。
+3. Unity Hub で **Open** を選択し、クローンしたディレクトリを指定して開きます。初回起動時に必要なパッケージがインポートされます。
+
+## 必要なパッケージ
+必須パッケージは [`Packages/manifest.json`](Packages/manifest.json) で定義されています。主なものは以下の通りです。
+- `com.meta.xr.sdk.all` (Meta XR Integration)
+- `com.unity.xr.management`
+- `com.unity.xr.oculus`
+- `com.unity.inputsystem`
+- `com.unity.visualscripting`
+
+Unity から依存関係について確認を求められたら、これらのパッケージがインストールされていることを確認してください。
+
+## ビルドと実行
+1. Unity の **Build Settings** (File > Build Settings...) を開きます。
+2. ビルドに含めるシーンとして `Main.unity` などを追加します。
+3. 対象プラットフォームを選択します (Oculus デバイスの場合は **Android** を選択)。
+4. **Build** もしくは **Build and Run** を実行します。
+
+サンプルは Oculus デバイスでテストされていますが、Unity エディタ上でも動作します。
+
+## 主なシーンとスクリプト
+`Assets/Scenes` フォルダーには次の 3 つのシーンがあります。
+- `Main.unity`
+- `BuildTest.unity`
+- `MRTK_scene.unity`
+
+ポータルの動作に関わる主要なスクリプトは `Assets/Script` フォルダーにあります。
+- `PortalManager.cs` – ポータルの出入りと AR/VR の切り替えを管理します。
+- `ClippingPlane_Origin.cs` – ポータル通過時にオブジェクトを隠す／表示するためのクリッピングプレーンを制御します。
+
+以上を参考に、ポータル処理をカスタマイズしてみてください。

--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# InMirror
+
+日本語版のREADMEは[README.ja.md](README.ja.md)をご覧ください。
+
+This repository contains a simple AR/VR portal demonstration created with Unity. The demo shows how to switch between augmented reality and virtual reality worlds through a portal effect.
+
+## Opening the Project
+
+1. Install **Unity 6000.0.36f1** or later.
+2. Clone this repository and launch Unity Hub.
+3. In Unity Hub choose **Open**, browse to the cloned directory and select it. Unity will import the required packages on first load.
+
+## Required Packages
+
+The project uses several packages defined in [`Packages/manifest.json`](Packages/manifest.json). Important ones include:
+
+- `com.meta.xr.sdk.all` (Meta XR Integration)
+- `com.unity.xr.management`
+- `com.unity.xr.oculus`
+- `com.unity.inputsystem`
+- `com.unity.visualscripting`
+
+Make sure these packages are installed when Unity prompts you about missing dependencies.
+
+## Build and Run
+
+1. Open **Build Settings** in Unity (File > Build Settings...).
+2. Add the desired scene (e.g. `Main.unity`) to the build list.
+3. Choose your target platform (for Oculus devices select **Android**).
+4. Click **Build** or **Build and Run**.
+
+The sample has been tested on Oculus devices but can be run in the Unity editor as well.
+
+## Main Scenes and Scripts
+
+The project contains three scenes located in `Assets/Scenes`:
+
+- `Main.unity`
+- `BuildTest.unity`
+- `MRTK_scene.unity`
+
+Core logic for the portal behaviour is implemented in two scripts located in `Assets/Script`:
+
+- `PortalManager.cs` – manages entering/exiting the portal and switching between AR and VR rendering.
+- `ClippingPlane_Origin.cs` – handles the clipping plane used to hide or reveal objects when passing through the portal.
+
+Feel free to explore and modify these scripts to adapt the portal behaviour to your needs.
+
+


### PR DESCRIPTION
## Summary
- link to a Japanese README from the main README
- add `README.ja.md` with translations

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683ff25536f08332977657170f9c0037